### PR TITLE
Allow a custom server handler to wrap the server renderer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
+    "mustache": "^2.3.0",
+    "node-sass": "^4.5.3",
+    "node-sass-json-importer": "^3.0.2",
     "require-from-string": "^1.2.1",
     "source-map-support": "^0.4.2"
   },

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,0 +1,21 @@
+
+const createConnectHandler = (error, serverRenderer) => (req, res, next) => {
+    debug(`Receive request ${req.url}`);
+    if (error) {
+        return next(error);
+    }
+    serverRenderer(req, res, next);
+};
+
+const createKoaHandler = (error, serverRenderer) => async (ctx, next) => {
+    debug(`Receive request ${ctx.url}`);
+    if (error) {
+        ctx.throw(error);
+    }
+    await serverRenderer(ctx, next);
+};
+
+module.exports = {
+  createConnectHandler,
+  createKoaHandler,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,12 @@ const path = require('path');
 const requireFromString = require('require-from-string');
 const MultiCompiler = require('webpack/lib/MultiCompiler');
 const sourceMapSupport = require('source-map-support');
+const { createConnectHandler } = require('./handlers');
 
 const DEFAULTS = {
     chunkName: 'main',
-    serverRendererOptions: {}
+    serverRendererOptions: {},
+    createHandler: createConnectHandler,
 };
 
 function interopRequireDefault(obj) {
@@ -129,12 +131,8 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         }
     });
 
-    return (req, res, next) => {
-        debug(`Receive request ${req.url}`);
-        if (error) {
-            return next(error);
-        }
-        serverRenderer(req, res, next);
+    return function () {
+        return options.createHandler(error, serverRenderer)(...arguments);
     };
 }
 


### PR DESCRIPTION
This allows support for any server. Included handlers are Express,
Connect, and Koa. The default handler is Express/Connect.

closes
https://github.com/60frames/webpack-hot-server-middleware/issues/28